### PR TITLE
Hide weather if no weather entity specified

### DIFF
--- a/dist/air-visual-card.js
+++ b/dist/air-visual-card.js
@@ -247,7 +247,7 @@ class AirVisualCard extends HTMLElement {
       const hideFace = config.hide_face ? 1 : 0;
       const hideAQI = config.hide_aqi ? 1 : 0;
       const hideAPL = config.hide_apl ? 1 : 0;
-      const hideWeather = config.hide_weather ? 1 : 0;
+      const hideWeather = config.hide_weather || !config.weather ? 1 : 0;
       const speedUnit = config.speed_unit || 'mp/h';
       // points to local directory created by HACS installation
       const iconDirectory = config.icons || "/hacsfiles/air-visual-card";


### PR DESCRIPTION
Hide the weather info if no weather entity has been specified.  Treats this the same as if `hide_weather` is `true`.

Note for dev: Perhaps consider getting rid of `hide_weather` property altogether and only using the presence or absence of the `weather` sensor property to determine the Boolean value.

Fixes #51.