### PR TITLE
Fix #55 - Lovelace Crash

### DIFF
--- a/dist/air-visual-card.js
+++ b/dist/air-visual-card.js
@@ -422,7 +422,7 @@ class AirVisualCard extends HTMLElement {
         card_content += `<div class="city">${city} Air Quality Index</div>`;
       }
 
-      if (weatherEntity.split('.')[0] == 'weather') {
+      if (weatherEntity.split('.')[0] == 'weather' && hass.states[weatherEntity]) {
         tempValue = hass.states[weatherEntity].attributes['temperature'] + 'º';
         currentCondition = hass.states[weatherEntity].state;
         humidity = hass.states[weatherEntity].attributes['humidity'] + '%';


### PR DESCRIPTION
Lovelace crashes with this error if the user has no `weather.home` entity:
```
air-visual-card.js?hacstag=157674859200:426 Uncaught TypeError: Cannot read properties of undefined (reading 'attributes')
    at HTMLElement.set hass [as hass] (air-visual-card.js?hacstag=157674859209:426)
    at HTMLElement.value (hui-masonry-view.ts:44)
    at HTMLElement.value (hui-masonry-view.ts:44)
    at HTMLElement.t.addEventListener.once (hui-masonry-view.ts:44)
    at i (typography.js:181)
    at ha-logbook.ts:28
```

This issue is described in more detail here: https://github.com/dnguyen800/air-visual-card/issues/55

Please release this change soon, I want my Lovelace cards back.. 😞 